### PR TITLE
Add CI tests, code coverage reports, upload documentation automatically

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,24 +2,22 @@ using Documenter, JuLie
 
 #makedocs(sitename = "JuLie Documentation", modules = [JuLie])
 
-#makedocs(
-#    modules = [JuLie],
+makedocs(
+    modules = [JuLie],
 #    format = Documenter.HTML(
 #        # Use clean URLs, unless built as a "local" build
 #        prettyurls = !("local" in ARGS),
 #        canonical = "https://juliadocs.github.io/Documenter.jl/stable/",
 #    ),
-#    sitename = "JuLie.jl",
+    sitename = "JuLie Documentation",
 #    authors = "Ulrich Thiel",
-#    pages = [
-#        "About" => "index.md",
-#        "Combinatorics" => "combinatorics.md",
-#        "Lie theory" => "lie-theory.md"
-#    ]
-#)
-
-makedocs(sitename = "JuLie Documentation", modules = [JuLie])
+    pages = [
+        "About" => "index.md",
+        "Combinatorics" => "combinatorics.md",
+        "Lie theory" => "lie-theory.md"
+    ]
+)
 
 deploydocs(
-    repo = "github.com/schto223/JuLie.jl.git",
+    repo = "github.com/ulthiel/JuLie.jl.git",
 )

--- a/docs/src/combinatorics.md
+++ b/docs/src/combinatorics.md
@@ -1,0 +1,3 @@
+# Combinatorics
+
+TODO

--- a/docs/src/lie-theory.md
+++ b/docs/src/lie-theory.md
@@ -1,0 +1,13 @@
+# Lie Theory
+
+TODO
+
+
+HACK: let's just insert all docstring here, for the fun;
+if you use separate (sub-)modules for combinatris vs Lie theory,
+you can split things.
+
+```@autodocs
+Modules = [JuLie]
+Order   = [:function, :type]
+```


### PR DESCRIPTION
@ulthiel You'll probably have questions about this, I'll be happy to answer (we can also Jitsi/Phone/...)

To make the documentation deploy right, you need to setup a `DOCUMENTER_KEY`, as described [here](https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#Authentication:-SSH-Deploy-Keys) resp. [here](https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#travis-ssh). In a nutshell, do this:

1. dev JuLie and install DocumenterTools, e.g. like this
    ```
    ] dev .   # assuming JuLie is in the current dir
    ] add DocumenterTools
    ```
2.
    ```
    julia> using JuLie
    julia> DocumenterTools.genkeys(JuLie)
    ```
3. Put the results into your GitHub settings, as instructed by the output of these commands