### PR TITLE
Relax is_cartan_matrix and make CartanMatrix stricter; fix CartanMatrix for A1 and A1~

### DIFF
--- a/src/cartan_matrices.jl
+++ b/src/cartan_matrices.jl
@@ -7,6 +7,7 @@
 #
 ################################################################################
 
+import AbstractAlgebra: base_ring, nrows, ncols
 import AbstractAlgebra: MatElem, MatrixAlgebra, diagonal_matrix, matrix, zero_matrix
 import Nemo: fmpz
 
@@ -41,8 +42,12 @@ If you would like to generate block diagonal matrices you can do so with
 CartanMatrix(["A3~","G2","B12"])    #calls essentially CartanMatrix(['A','G','B'],[3,2,12],[true,false,false])
 ```
 """
-struct CartanMatrix{T} <: MatElem{T}
-   cm::MatElem{T}
+struct CartanMatrix <: MatElem{fmpz}
+   cm::MatElem{fmpz}
+   function CartanMatrix(m::MatElem{fmpz})
+      is_cartan_matrix(m) || throw(DomainError(m, "`m` must be a (generalized) Cartan matrix"))
+      new(m)
+   end
 end
 
 
@@ -53,6 +58,10 @@ end
 function Base.size(CM::CartanMatrix)
   return size(CM.cm)
 end
+
+base_ring(CM::CartanMatrix) = base_ring(CM.cm)
+nrows(CM::CartanMatrix) = nrows(CM.cm)
+ncols(CM::CartanMatrix) = ncols(CM.cm)
 
 function Base.size(CM::CartanMatrix, d::Int)
   return size(CM.cm, d)
@@ -80,7 +89,7 @@ end
 
 returns true iff C is a *(generalized)* **Cartan matrix**.
 """
-function is_cartan_matrix(C::CartanMatrix)
+function is_cartan_matrix(C::MatElem)
     #is square
     if size(C,1) != size(C,2)
         return false

--- a/src/cartan_matrices.jl
+++ b/src/cartan_matrices.jl
@@ -162,15 +162,20 @@ function CartanMatrix(type::Char, dim::Int, tilde=false::Bool)
             dim += 1
         end
         CM = diagonal_matrix(ZZ(2), dim)
-        CM[2,1] = -1
+        if dim > 1
+            CM[2,1] = -1
+            CM[dim-1,dim] = -1
+        end
         for j = 2:dim-1
             CM[j-1,j] = -1
             CM[j+1,j] = -1
         end
-        CM[dim-1,dim] = -1
         if tilde
-            CM[1,dim] = -1
-            CM[dim,1] = -1
+            if dim == 2  # A1~
+                CM[1,dim] = CM[dim,1] = -2
+            else
+                CM[1,dim] = CM[dim,1] = -1
+            end
         end
         return CartanMatrix(CM)
 
@@ -398,15 +403,20 @@ function CartanMatrix(types::Array{Char,1}, dims::Array{Int,1}, tildes::BitArray
             if tilde
                 dim += 1
             end
-            CM[2+c,1+c] = -1
+            if dim > 1
+                CM[2+c,1+c] = -1
+                CM[dim-1+c,dim+c] = -1
+            end
             for j = 2+c:dim-1+c
                 CM[j-1,j] = -1
                 CM[j+1,j] = -1
             end
-            CM[dim-1+c,dim+c] = -1
             if tilde
-                CM[1+c,dim+c] = -1
-                CM[dim+c,1+c] = -1
+                if dim == 2  # A1~
+                    CM[1+c,dim+c] = CM[dim+c,1+c] = -2
+                else
+                    CM[1+c,dim+c] = CM[dim+c,1+c] = -1
+                end
             end
 
         elseif type == 'B'

--- a/test/cartan_matrices.jl
+++ b/test/cartan_matrices.jl
@@ -1,9 +1,14 @@
+using AbstractAlgebra: matrix, zero_matrix
+
 @testset "Cartan matrices" begin
 
     @test !is_cartan_matrix(zero_matrix(ZZ, 2, 2))
     @test !is_cartan_matrix(zero_matrix(ZZ, 2, 2))
 
+    @test CartanMatrix("A1") == matrix(ZZ, 1, 1, [2])
+    @test CartanMatrix("A1~") == matrix(ZZ, 2, 2, [2 -2 ; -2 2])
     @test CartanMatrix("A2") == matrix(ZZ, 2, 2, [2 -1 ; -1 2])
+    @test CartanMatrix("A3") == matrix(ZZ, 3, 3, [2 -1 0; -1 2 -1 ; 0 -1 2])
 
     @test_throws DomainError CartanMatrix(zero_matrix(ZZ, 2, 2))
     @test_throws ArgumentError CartanMatrix("K2")

--- a/test/cartan_matrices.jl
+++ b/test/cartan_matrices.jl
@@ -1,0 +1,11 @@
+@testset "Cartan matrices" begin
+
+    @test !is_cartan_matrix(zero_matrix(ZZ, 2, 2))
+    @test !is_cartan_matrix(zero_matrix(ZZ, 2, 2))
+
+    @test CartanMatrix("A2") == matrix(ZZ, 2, 2, [2 -1 ; -1 2])
+
+    @test_throws DomainError CartanMatrix(zero_matrix(ZZ, 2, 2))
+    @test_throws ArgumentError CartanMatrix("K2")
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -365,3 +365,6 @@ end
 	end
 	@test check==true
 end
+
+
+include("cartan_matrices.jl")


### PR DESCRIPTION
- Allow applying is_cartan_matrix to any `MatElem` matrix
- Add inner constructor for CartanMatrix to prevent creation of CartanMatrix objects which do not represent a (generalized) Cartan matrix.
- Add some test for Cartan matrices
- Add a few more MatElem methods for CartanMatrix, to e.g. enable `==` for them
- Fix `CartanMatrix("A1")` and `CartanMatrix("A1~")`