### PR TITLE
CI: update codecov/codecov-action to v2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,21 +12,20 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - '1.3'
-          - '1.4'
-          - '1.5'
+          - '1.6'
+          - '1.7'
+          - '1.8'
           - 'nightly'
         julia-arch:
           - x64
         os:
           - ubuntu-latest
-          - macOS-latest
-        exclude:
+        include:
           # Reduce the number of macOS jobs, as fewer can be run in parallel
           - os: macos-latest
-            julia-version: '1.3'
+            julia-version: '1.6'
           - os: macos-latest
-            julia-version: '1.4'
+            julia-version: '1.8'
 
     steps:
       - uses: actions/checkout@v2
@@ -71,4 +70,4 @@ jobs:
         uses: julia-actions/julia-processcoverage@v1
       - name: "Upload coverage data to Codecov"
         continue-on-error: true
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2


### PR DESCRIPTION
v1 will be disabled February 1, 2022; see https://github.com/codecov/codecov-action
